### PR TITLE
Solved OLED flickering

### DIFF
--- a/main.c
+++ b/main.c
@@ -89,7 +89,8 @@ uint8_t display_buffer[LCDHEIGHT * LCDWIDTH / 8] = {
  	/* Initialize the OLED module */
 	init_ssd1306();
 	
-	clear();
+	
+	clearBuffer();
 	
 	
 	
@@ -101,13 +102,17 @@ uint8_t display_buffer[LCDHEIGHT * LCDWIDTH / 8] = {
 	
 	UG_PutString(0, 0, "Initialization Completed! \n");
 	
+	clearDisplay();
+	
 	display(display_buffer);
 	
 	delay_ms(1000);
 	
-	clear();
+	clearBuffer();
 	
 	UG_PutString(0, 0, "Initializing GPS... \n");
+	
+	clearDisplay();
 	
 	display(display_buffer);
 	
@@ -137,9 +142,11 @@ uint8_t display_buffer[LCDHEIGHT * LCDWIDTH / 8] = {
  	
  	delay_ms(1000);
 	
-	clear();
+	clearBuffer();
 	
 	UG_PutString(0, 0, "Waiting for GPS data... \n");
+	
+	clearDisplay();
 	
 	display(display_buffer);
  	
@@ -157,7 +164,7 @@ uint8_t display_buffer[LCDHEIGHT * LCDWIDTH / 8] = {
  		if((validity[0] == '1') || (validity[0] == '2'))
  		{
  		
- 			clear();
+ 			clearBuffer();
  			
 			/* Get the local time stored in the 'time' array
 			   and send it to the pc */
@@ -175,7 +182,8 @@ uint8_t display_buffer[LCDHEIGHT * LCDWIDTH / 8] = {
 			   and send it to the pc */
 			getLongitude();
 			
-			//display(display_buffer);
+			clearDisplay();
+			display(display_buffer);
 			
 			//stringSend("\n");
  			
@@ -184,10 +192,12 @@ uint8_t display_buffer[LCDHEIGHT * LCDWIDTH / 8] = {
  		/* Current fix is not valid */
  		else
  		{
- 			clear();
+ 			clearBuffer();
  			
  			UG_PutString(0, 0, "No GPS fix found.....!");
-	
+			
+			clearDisplay();
+			
 			display(display_buffer);
  			
  			stringSend("No GPS fix found.....");

--- a/nmea_indexing/nmea.c
+++ b/nmea_indexing/nmea.c
@@ -191,7 +191,7 @@ void getlocalTime(void)
 		
 		UG_PutString(0, 0, localtime);
 	
-		display(display_buffer);
+		//display(display_buffer);
 		
 	}
 	else
@@ -235,7 +235,7 @@ void getSpeed(void)
 		
 		UG_PutString(104, 0, "Km");
 	
-		display(display_buffer);
+		//display(display_buffer);
 		
 	}
 	else
@@ -307,7 +307,7 @@ void getLatitude(void)
 		
 		UG_PutString(0, 12, latstring);
 	
-		display(display_buffer);
+		//display(display_buffer);
 		
 	}
 	else
@@ -385,7 +385,7 @@ void getLongitude(void)
 		
 		UG_PutString(0, 24, lonstring);
 	
-		display(display_buffer);
+		//display(display_buffer);
 		
 	}
 	else

--- a/oled/ssd1306.c
+++ b/oled/ssd1306.c
@@ -288,9 +288,9 @@ void display(uint8_t * buffer){
 
 
 /*
- * Function : clear
+ * Function : clearDisplay
  *
- * Description : Clear the buffer array (write 0x00 to all locations).
+ * Description : Clear GDDRAM of the display (write 0x00 to all locations).
  *
  * Notes : This function is specific to the I2C module in TM4C1294NCPDT controller and to the SSD1306 command set.
  *
@@ -298,9 +298,9 @@ void display(uint8_t * buffer){
  */
 
 
-void clear(void){
+void clearDisplay(void){
 	
-	/************** First clear the GDDRAM *************/
+	/************** Clear the GDDRAM *************/
 	/* Setting OLED address (0x3C) and setting controller in transmit mode*/
 	I2C2_MSA_R |= ((OLED_ADDRESS << 1) | TRANSMIT_MODE);
 	
@@ -333,16 +333,29 @@ void clear(void){
 	while((I2C2_MCS_R & BUSY) == 0);
 	
 	while((I2C2_MCS_R & BUSY) == 1); // Checking the transmittion end.
+	
+}
 
 
-	/***************** Secondly clear the local display buffer***************/
+
+
+/*
+ * Function : clearDisplay
+ *
+ * Description : Clear GDDRAM of the display (write 0x00 to all locations).
+ *
+ * Notes : This function is specific to the I2C module in TM4C1294NCPDT controller and to the SSD1306 command set.
+ *
+ * Returns : None.
+ */
+
+void clearBuffer(void){
+	/***************** Clear the local display buffer***************/
 	for(uint16_t i = 0; i < (LCDHEIGHT * LCDWIDTH / 8); i++){
 		
 		display_buffer[i] = 0x00;	
 		
 	}
-	
-	display(display_buffer);
 	
 }
 
@@ -438,7 +451,7 @@ void init_ssd1306(void){
     		
     	}
     	
-    	clear();
+    	clearDisplay();
     	
     /* Re-set contrast to normal value */
 	OLED_command(0x81);                    // SETCONTRAST          0x81

--- a/oled/ssd1306.h
+++ b/oled/ssd1306.h
@@ -46,7 +46,9 @@ void OLED_data(uint8_t data);
 
 void display(uint8_t *);
 
-void clear(void);
+void clearDisplay(void);
+
+void clearBuffer(void);
 
 
 #endif 


### PR DESCRIPTION
OLED display clear and writeback causes a flickering effect on the display. It has been fixed by splitting the clear function to each for buffer and display RAM. 